### PR TITLE
Fix STL dependency (JitPack 0.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ mvn test
 mvn javafx:run
 ```
 
+The STL library is resolved via [JitPack](https://jitpack.io), so Maven will
+download it automatically during the build.
+
 The CLI version can still be run using the exec plugin profile.
 
 Screenshots are available in `screenshots/gui.png`.

--- a/pom.xml
+++ b/pom.xml
@@ -33,21 +33,16 @@
             <version>21.0.2</version>
         </dependency>
         <dependency>
-            <groupId>de.javagl</groupId>
-            <artifactId>stl</artifactId>
-            <version>0.3.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit5</artifactId>
             <version>4.0.16-alpha</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-  <groupId>com.github.javagl</groupId>
-  <artifactId>stl</artifactId>
-  <version>v0.4.0</version>   
-</dependency>
+            <groupId>com.github.javagl</groupId>
+            <artifactId>stl</artifactId>
+            <version>0.4.0</version>
+        </dependency>
     </dependencies>
     <repositories>
   <repository>


### PR DESCRIPTION
## Summary
- fetch the STL library from JitPack
- document the JitPack dependency

## Testing
- `mvn -U test` *(fails: `mvn` not found)*