### PR TITLE
Disable STL export temporarily

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,11 +38,6 @@
             <version>4.0.16-alpha</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.github.javagl</groupId>
-            <artifactId>stl</artifactId>
-            <version>0.4.0</version>
-        </dependency>
     </dependencies>
     <repositories>
   <repository>

--- a/src/main/java/org/example/flowmod/FlowModifierUI.java
+++ b/src/main/java/org/example/flowmod/FlowModifierUI.java
@@ -83,7 +83,10 @@ public class FlowModifierUI extends Application {
         table.getColumns().addAll(c1, c2, c3, c4);
 
         summaryLabel = new Label();
-        VBox resultsBox = new VBox(10, table, summaryLabel);
+        Button exportStl = new Button("Export STL");
+        exportStl.setId("exportStlButton");
+        exportStl.setDisable(true); // Feature temporarily disabled
+        VBox resultsBox = new VBox(10, table, summaryLabel, exportStl);
         resultsTab.setContent(resultsBox);
 
         Scene scene = new Scene(tabs, 600, 400);

--- a/src/main/java/org/example/flowmod/model3d/ExportService.java
+++ b/src/main/java/org/example/flowmod/model3d/ExportService.java
@@ -1,18 +1,16 @@
 package org.example.flowmod.model3d;
 
-import de.javagl.stl.STLExporter;
 import javafx.scene.shape.TriangleMesh;
 
 import java.io.File;
-import java.io.FileOutputStream;
 
 public final class ExportService {
     private ExportService() {}
 
-    public static void saveAsStl(File file, TriangleMesh mesh) throws Exception {
-        STLExporter exporter = new STLExporter();
-        try (FileOutputStream fos = new FileOutputStream(file)) {
-            exporter.export(mesh, fos);
-        }
+    /**
+     * Temporary stub while STL export is disabled.
+     */
+    public static void saveAsStl(File file, TriangleMesh mesh) {
+        throw new UnsupportedOperationException("STL export temporarily disabled");
     }
 }


### PR DESCRIPTION
## Summary
- remove STL library dependency
- stub out ExportService.saveAsStl
- disable the Export STL button in FlowModifierUI

## Testing
- `mvn clean javafx:run` *(fails: `mvn: command not found`)*