### PR TITLE
Compile clean-up: remove STL and add PipeSpecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ mvn test
 mvn javafx:run
 ```
 
-The STL library is resolved via [JitPack](https://jitpack.io), so Maven will
-download it automatically during the build.
+The project still references the [JitPack](https://jitpack.io) repository, but
+STL export is temporarily disabled while the library selection is finalised.
 
 The CLI version can still be run using the exec plugin profile.
 

--- a/src/main/java/org/example/flowmod/AppLauncher.java
+++ b/src/main/java/org/example/flowmod/AppLauncher.java
@@ -2,8 +2,8 @@ package org.example.flowmod;
 
 import com.google.gson.Gson;
 import org.example.flowmod.engine.FlowPhysics;
-import org.example.flowmod.engine.GraduatedHoleOptimizer;
-import org.example.flowmod.engine.DesignResult;
+
+import org.example.flowmod.HoleOptimizer;
 import org.example.flowmod.HoleLayout;
 import org.example.flowmod.HoleSpec;
 
@@ -21,15 +21,13 @@ public class AppLauncher {
         }
 
         FlowPhysics.Result phys = FlowPhysics.compute(settings.pipe());
-        GraduatedHoleOptimizer opt = new GraduatedHoleOptimizer();
-        DesignResult result = opt.optimise(
+        HoleLayout layout = HoleOptimizer.optimise(
                 settings.pipe(),
                 settings.filter(),
                 settings.drillMinMm(),
                 settings.drillMaxMm(),
                 settings.rows(),
                 settings.Cd());
-        HoleLayout layout = result.holeLayout();
 
         System.out.println("Row | Pos mm | \u00D8 mm | L/min");
         for (HoleSpec h : layout.holes()) {

--- a/src/main/java/org/example/flowmod/FilterSpecs.java
+++ b/src/main/java/org/example/flowmod/FilterSpecs.java
@@ -1,3 +1,0 @@
-package org.example.flowmod;
-
-public record FilterSpecs(double openAreaPercent, double faceVelocityMaxMs) {}

--- a/src/main/java/org/example/flowmod/FlowModifierUI.java
+++ b/src/main/java/org/example/flowmod/FlowModifierUI.java
@@ -9,6 +9,8 @@ import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 import org.example.flowmod.engine.FlowPhysics;
+import org.example.flowmod.engine.FilterSpecs;
+import org.example.flowmod.engine.PipeSpecs;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/example/flowmod/HoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/HoleOptimizer.java
@@ -1,0 +1,41 @@
+package org.example.flowmod;
+
+import org.example.flowmod.engine.DesignResult;
+import org.example.flowmod.engine.FilterSpecs;
+import org.example.flowmod.engine.GraduatedHoleOptimizer;
+import org.example.flowmod.engine.ModifierDesignStrategy;
+import org.example.flowmod.engine.PipeSpecs;
+
+/** Convenience wrapper delegating to {@link GraduatedHoleOptimizer}. */
+public class HoleOptimizer implements ModifierDesignStrategy {
+
+    private final GraduatedHoleOptimizer delegate;
+
+    public HoleOptimizer() {
+        this.delegate = new GraduatedHoleOptimizer();
+    }
+
+    @Override
+    public DesignResult optimise(PipeSpecs pipe,
+                                 FilterSpecs filter,
+                                 double drillMinMm,
+                                 double drillMaxMm,
+                                 int rows,
+                                 double Cd) {
+        return delegate.optimise(pipe, filter, drillMinMm, drillMaxMm, rows, Cd);
+    }
+
+    /**
+     * Optimise using a new instance of the underlying {@link GraduatedHoleOptimizer}.
+     */
+    public static HoleLayout optimise(PipeSpecs pipe,
+                                      FilterSpecs filter,
+                                      double drillMinMm,
+                                      double drillMaxMm,
+                                      int rows,
+                                      double Cd) {
+        return new HoleOptimizer()
+                .optimise(pipe, filter, drillMinMm, drillMaxMm, rows, Cd)
+                .holeLayout();
+    }
+}

--- a/src/main/java/org/example/flowmod/Settings.java
+++ b/src/main/java/org/example/flowmod/Settings.java
@@ -1,5 +1,8 @@
 package org.example.flowmod;
 
+import org.example.flowmod.engine.FilterSpecs;
+import org.example.flowmod.engine.PipeSpecs;
+
 public record Settings(
         PipeSpecs pipe,
         FilterSpecs filter,

--- a/src/main/java/org/example/flowmod/engine/FilterSpecs.java
+++ b/src/main/java/org/example/flowmod/engine/FilterSpecs.java
@@ -1,0 +1,4 @@
+package org.example.flowmod.engine;
+
+/** Specifications for the outlet filter. */
+public record FilterSpecs(double openAreaPercent, double faceVelocityMaxMs) {}

--- a/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
@@ -2,15 +2,15 @@ package org.example.flowmod.engine;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.example.flowmod.FilterSpecs;
+import org.example.flowmod.engine.FilterSpecs;
 import org.example.flowmod.HoleLayout;
 import org.example.flowmod.HoleSpec;
-import org.example.flowmod.PipeSpecs;
+import org.example.flowmod.engine.PipeSpecs;
 import org.example.flowmod.engine.DesignResult;
 import org.example.flowmod.engine.ModifierDesignStrategy;
 
 public final class GraduatedHoleOptimizer implements ModifierDesignStrategy {
-    private GraduatedHoleOptimizer() {}
+    public GraduatedHoleOptimizer() {}
 
     @Override
     public DesignResult optimise(PipeSpecs pipe,

--- a/src/main/java/org/example/flowmod/engine/ModifierDesignStrategy.java
+++ b/src/main/java/org/example/flowmod/engine/ModifierDesignStrategy.java
@@ -1,7 +1,7 @@
 package org.example.flowmod.engine;
 
-import org.example.flowmod.FilterSpecs;
-import org.example.flowmod.PipeSpecs;
+import org.example.flowmod.engine.FilterSpecs;
+import org.example.flowmod.engine.PipeSpecs;
 
 public interface ModifierDesignStrategy {
     DesignResult optimise(PipeSpecs pipe,

--- a/src/main/java/org/example/flowmod/engine/PipeSpecs.java
+++ b/src/main/java/org/example/flowmod/engine/PipeSpecs.java
@@ -1,3 +1,4 @@
-package org.example.flowmod;
+package org.example.flowmod.engine;
 
+/** Specifications for the upstream pipe and modifier. */
 public record PipeSpecs(double innerDiameterMm, double flowRateLpm, double modifierLengthMm) {}

--- a/src/main/java/org/example/flowmod/engine/VaneDiffuserOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/VaneDiffuserOptimizer.java
@@ -1,7 +1,7 @@
 package org.example.flowmod.engine;
 
-import org.example.flowmod.FilterSpecs;
-import org.example.flowmod.PipeSpecs;
+import org.example.flowmod.engine.FilterSpecs;
+import org.example.flowmod.engine.PipeSpecs;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/example/flowmod/model3d/ModelBuilder.java
+++ b/src/main/java/org/example/flowmod/model3d/ModelBuilder.java
@@ -2,7 +2,7 @@ package org.example.flowmod.model3d;
 
 import javafx.scene.shape.MeshView;
 import javafx.scene.shape.TriangleMesh;
-import org.example.flowmod.PipeSpecs;
+import org.example.flowmod.engine.PipeSpecs;
 import org.example.flowmod.engine.DesignResult;
 
 public final class ModelBuilder {

--- a/src/main/java/org/example/flowmod/ui/FlowModifierStudio.java
+++ b/src/main/java/org/example/flowmod/ui/FlowModifierStudio.java
@@ -102,7 +102,7 @@ public class FlowModifierStudio extends Application {
         FilterSpecs filter = new FilterSpecs(vals[3], vals[4]);
 
         ModifierDesignStrategy strategy = algoBox.getValue().equals("Vanes") ?
-                new VaneDiffuserOptimizer() : new GraduatedHoleOptimizer();
+                new VaneDiffuserOptimizer() : new HoleOptimizer();
         DesignResult result = strategy.optimise(pipe, filter, vals[5], vals[6], DEFAULT_ROWS, DEFAULT_CD);
         if (result.holeLayout() != null) {
             table.getItems().setAll(result.holeLayout().holes());

--- a/src/test/java/org/example/flowmod/FlowPhysicsTest.java
+++ b/src/test/java/org/example/flowmod/FlowPhysicsTest.java
@@ -3,6 +3,7 @@ package org.example.flowmod;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 import org.example.flowmod.engine.FlowPhysics;
+import org.example.flowmod.engine.PipeSpecs;
 
 public class FlowPhysicsTest {
     @Test

--- a/src/test/java/org/example/flowmod/HoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/HoleOptimizerTest.java
@@ -2,6 +2,8 @@ package org.example.flowmod;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
+import org.example.flowmod.engine.FilterSpecs;
+import org.example.flowmod.engine.PipeSpecs;
 
 public class HoleOptimizerTest {
     @Test


### PR DESCRIPTION
## Summary
- create `PipeSpecs` and `FilterSpecs` in the engine layer
- expose `GraduatedHoleOptimizer` and provide `HoleOptimizer` facade
- refactor UI/CLI/tests to use new API
- update README note about STL export

## Testing
- `mvn -U clean test` *(fails: `mvn: command not found`)*
- `mvn -q javafx:run` *(fails: `mvn: command not found`)*