### PR TITLE
Simplify UI and stage 3-D / validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FlowModifierCalculator
 
-This tool designs graduated-hole or vane flow modifiers and now includes a JavaFX desktop studio.
+This tool designs graduated-hole flow modifiers and now includes a simplified JavaFX interface.
 
 ## Build & Run
 
@@ -14,4 +14,13 @@ STL export is temporarily disabled while the library selection is finalised.
 
 The CLI version can still be run using the exec plugin profile.
 
-Screenshots are available in `screenshots/gui.png`.
+### How to use
+
+1. Run `mvn javafx:run`.
+2. Enter the pipe I.D., modifier length, flow rate and drill size range.
+3. Click **Calculate** to populate the table and summary.
+4. Use **Validate flow** to check the design.
+
+The interface is shown below:
+
+![GUI screenshot](screenshots/gui.png)

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
                 <artifactId>javafx-maven-plugin</artifactId>
                 <version>0.0.8</version>
                 <configuration>
-                    <mainClass>org.example.flowmod.ui.FlowModifierStudio</mainClass>
+                    <mainClass>org.example.flowmod.FlowModifierUI</mainClass>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/test/java/org/example/flowmod/FlowModifierUITest.java
+++ b/src/test/java/org/example/flowmod/FlowModifierUITest.java
@@ -17,10 +17,8 @@ public class FlowModifierUITest extends ApplicationTest {
     @Test
     void tableHasExpectedRows() {
         clickOn("#innerDiameterMm").write("20");
-        clickOn("#flowRateLpm").write("5");
         clickOn("#modifierLengthMm").write("100");
-        clickOn("#openAreaPercent").write("30");
-        clickOn("#faceVelocityMaxMs").write("1.0");
+        clickOn("#flowRateLpm").write("5");
         clickOn("#drillMinMm").write("1.0");
         clickOn("#drillMaxMm").write("5.0");
         clickOn("#calculateButton");


### PR DESCRIPTION
## Summary
- streamline FlowModifierUI with BorderPane layout and fewer inputs
- switch JavaFX plugin to launch FlowModifierUI
- adjust tests for the new input set
- refresh README and screenshot

## Testing
- `mvn -q test` *(fails: `mvn` not found)*