### PR TITLE
UI revamp + auto max Ø

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The CLI version can still be run using the exec plugin profile.
 ### How to use
 
 1. Run `mvn javafx:run`.
-2. Enter the pipe I.D., modifier length, flow rate and drill size range.
-3. Click **Calculate** to populate the table and summary.
-4. Use **Validate flow** to check the design.
+2. Enter the pipe I.D., flow rate and minimum drill size (defaults to 4 mm).
+3. Click **Calculate** to auto-design the perforated strip.
+4. **Export CSV** saves the hole layout; other actions are marked TODO.
 
 The interface is shown below:
 

--- a/src/main/java/org/example/flowmod/AutoCoreApp.java
+++ b/src/main/java/org/example/flowmod/AutoCoreApp.java
@@ -1,0 +1,25 @@
+package org.example.flowmod;
+
+import org.example.flowmod.engine.PerforatedCoreOptimizer;
+
+public final class AutoCoreApp {
+    private AutoCoreApp() {}
+
+    public static void main(String[] args) {
+        if (args.length < 2) {
+            System.err.println("Usage: AutoCoreApp ID_mm Flow_Lpm [dMin]");
+            System.exit(1);
+        }
+        double id = Double.parseDouble(args[0]);
+        double flow = Double.parseDouble(args[1]);
+        double dMin = args.length > 2 ? Double.parseDouble(args[2]) : 4.0;
+
+        var layout = PerforatedCoreOptimizer.autoDesign(id, flow, dMin);
+
+        System.out.println("index,position_mm,diameter_mm,predicted_lpm");
+        for (var h : layout.holes()) {
+            System.out.printf("%d,%.2f,%.2f,%.2f%n", h.index(), h.positionMm(), h.diameterMm(), h.predictedLpm());
+        }
+        System.out.printf("error_pct,%.2f%n", layout.worstCaseErrorPct());
+    }
+}

--- a/src/main/java/org/example/flowmod/engine/PerforatedCoreOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/PerforatedCoreOptimizer.java
@@ -14,6 +14,28 @@ public final class PerforatedCoreOptimizer {
     private PerforatedCoreOptimizer() {}
 
     /**
+     * Designs a perforated core using automatic rules.
+     * The strip length defaults to five times the pipe diameter and the
+     * maximum drill size is 20% of the pipe diameter rounded to the nearest
+     * 0.5 mm.
+     *
+     * @param pipeDiameterMm pipe inner diameter
+     * @param flowLpm        target total flow rate
+     * @param drillMinMm     minimum drill diameter
+     * @return optimised hole layout
+     */
+    public static HoleLayout autoDesign(double pipeDiameterMm,
+                                        double flowLpm,
+                                        double drillMinMm) {
+        double stripLength = pipeDiameterMm * 5.0;
+        double maxDia = Math.round((pipeDiameterMm * 0.20) / 0.5) * 0.5;
+
+        PipeSpecs pipe = new PipeSpecs(pipeDiameterMm, flowLpm, stripLength);
+        return design(pipe, stripLength, flowLpm,
+                      drillMinMm, maxDia, 5.0, 0.5);
+    }
+
+    /**
      * Designs a perforated inlet core.
      *
      * @param pipe           upstream pipe specifications

--- a/src/test/java/org/example/flowmod/FlowModifierUITest.java
+++ b/src/test/java/org/example/flowmod/FlowModifierUITest.java
@@ -2,6 +2,7 @@ package org.example.flowmod;
 
 import javafx.scene.control.TableView;
 import javafx.stage.Stage;
+import org.example.flowmod.HoleSpec;
 import org.junit.jupiter.api.Test;
 import org.testfx.framework.junit5.ApplicationTest;
 
@@ -17,14 +18,12 @@ public class FlowModifierUITest extends ApplicationTest {
     @Test
     void tableHasExpectedRows() {
         clickOn("#innerDiameterMm").write("20");
-        clickOn("#modifierLengthMm").write("100");
         clickOn("#flowRateLpm").write("5");
         clickOn("#drillMinMm").write("1.0");
-        clickOn("#drillMaxMm").write("5.0");
         clickOn("#calculateButton");
 
         TableView<HoleSpec> table = lookup("#resultTable").query();
-        assertEquals(10, table.getItems().size());
+        assertTrue(table.getItems().size() >= 3);
     }
 }
 

--- a/src/test/java/org/example/flowmod/PerforatedCoreOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/PerforatedCoreOptimizerTest.java
@@ -17,4 +17,12 @@ public class PerforatedCoreOptimizerTest {
             assertTrue(h.diameterMm() >= 2.0 && h.diameterMm() <= 6.0);
         }
     }
+
+    @Test
+    void autoDesignUsesMaxRule() {
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(150, 5000, 4.0);
+        double max = layout.holes().stream().mapToDouble(HoleSpec::diameterMm).max().orElse(0);
+        assertEquals(30.0, max, 0.0001);
+        assertTrue(layout.worstCaseErrorPct() <= 5.0);
+    }
 }


### PR DESCRIPTION
## Summary
- auto-design perforated cores with default max Ø
- update FlowModifierUI for simplified inputs and new actions
- add AutoCoreApp CLI example
- export CSV from UI and display summary
- update tests and docs

## Testing
- `mvn test` *(fails: `mvn: command not found`)*
- `mvn javafx:run` *(fails: `mvn: command not found`)*