### PR TITLE
Structural ligament rule (web ≥ 0.3 t)

### DIFF
--- a/src/main/java/org/example/flowmod/AutoCoreApp.java
+++ b/src/main/java/org/example/flowmod/AutoCoreApp.java
@@ -8,7 +8,7 @@ public final class AutoCoreApp {
 
     public static void main(String[] args) {
         if (args.length < 2) {
-            System.err.println("Usage: AutoCoreApp ID_mm Flow_Gpm [dMin=4] [step=0.5]");
+            System.err.println("Usage: AutoCoreApp ID_mm Flow_Gpm [dMin=4] [step=0.5] [wall]");
             System.exit(1);
         }
         double id = Double.parseDouble(args[0]);
@@ -16,7 +16,8 @@ public final class AutoCoreApp {
         double flowLpm = UnitConv.gpmToLpm(flowGpm);
         double dMin = args.length > 2 ? Double.parseDouble(args[2]) : 4.0;
         double step = args.length > 3 ? Double.parseDouble(args[3]) : 0.5;
-        var layout = PerforatedCoreOptimizer.autoDesign(id, flowLpm, dMin, step);
+        Double wall = args.length > 4 ? Double.parseDouble(args[4]) : null;
+        var layout = PerforatedCoreOptimizer.autoDesign(id, flowLpm, dMin, step, wall);
 
         System.out.println("index,position_mm,diameter_mm,predicted_lpm");
         for (var h : layout.holes()) {

--- a/src/main/java/org/example/flowmod/utils/PipeSchedule.java
+++ b/src/main/java/org/example/flowmod/utils/PipeSchedule.java
@@ -1,0 +1,21 @@
+package org.example.flowmod.utils;
+
+/** Utility for pipe wall thickness defaults. */
+public final class PipeSchedule {
+    private PipeSchedule() {}
+
+    /**
+     * Approximate schedule 40 wall thickness for a given pipe ID.
+     * Values are simplified for this demo.
+     * @param dPipeMm pipe inner diameter in millimetres
+     * @return wall thickness in millimetres
+     */
+    public static double defaultWall(double dPipeMm) {
+        if (dPipeMm <= 25) return 2.5;
+        if (dPipeMm <= 50) return 3.5;
+        if (dPipeMm <= 80) return 4.0;
+        if (dPipeMm <= 150) return 6.0;
+        if (dPipeMm <= 250) return 8.0;
+        return 10.0;
+    }
+}

--- a/src/test/java/org/example/flowmod/PerforatedCoreOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/PerforatedCoreOptimizerTest.java
@@ -20,7 +20,7 @@ public class PerforatedCoreOptimizerTest {
 
     @Test
     void autoDesignRespectsCap() {
-        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(300, 100, 4.0, 0.5);
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(300, 100, 4.0, 0.5, null);
         double max = layout.holes().stream().mapToDouble(HoleSpec::diameterMm).max().orElse(0);
         assertTrue(max <= 75.0);
         assertTrue(layout.worstCaseErrorPct() <= 5.0);
@@ -28,7 +28,7 @@ public class PerforatedCoreOptimizerTest {
 
     @Test
     void highFlowAddsRows() {
-        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(300, 5000, 4.0, 0.5);
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(300, 5000, 4.0, 0.5, null);
         assertTrue(layout.holes().size() >= 20);
         assertTrue(layout.holes().size() <= 60);
         assertTrue(layout.worstCaseErrorPct() <= 5.0);
@@ -36,14 +36,14 @@ public class PerforatedCoreOptimizerTest {
 
     @Test
     void lowFlowDoesNotExceedMaxRows() {
-        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(300, 40, 4.0, 0.5);
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(300, 40, 4.0, 0.5, null);
         assertTrue(layout.holes().size() <= 60);
         assertTrue(layout.worstCaseErrorPct() <= 5.0);
     }
 
     @Test
     void stepTwoMmProducesMultiples() {
-        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(150, 100, 4.0, 2.0);
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(150, 100, 4.0, 2.0, null);
         for (HoleSpec h : layout.holes()) {
             double mod = Math.round(h.diameterMm() / 2.0);
             assertEquals(mod * 2.0, h.diameterMm(), 0.0001);
@@ -52,9 +52,27 @@ public class PerforatedCoreOptimizerTest {
 
     @Test
     void halfMillimetreGranularityPresent() {
-        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(150, 100, 4.0, 0.5);
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(150, 100, 4.0, 0.5, null);
         boolean hasHalf = layout.holes().stream()
                 .anyMatch(h -> Math.abs(h.diameterMm() - Math.round(h.diameterMm())) > 0.0001);
         assertTrue(hasHalf);
+    }
+
+    @Test
+    void ligamentRule150mmWall6() {
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(150, 100, 4.0, 0.5, 6.0);
+        double pitch = 150 * 5.0 / (layout.holes().size() + 1);
+        for (HoleSpec h : layout.holes()) {
+            assertTrue(pitch >= h.diameterMm() + 1.8);
+        }
+    }
+
+    @Test
+    void ligamentRule100mmWall2() {
+        HoleLayout layout = PerforatedCoreOptimizer.autoDesign(100, 100, 4.0, 0.5, 2.0);
+        double pitch = 100 * 5.0 / (layout.holes().size() + 1);
+        for (HoleSpec h : layout.holes()) {
+            assertTrue(pitch >= h.diameterMm() + 0.6);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add optional wall thickness field to UI
- provide PipeSchedule.defaultWall for default pipes
- enforce min ligament in PerforatedCoreOptimizer
- support optional wall thickness in CLI
- test ligament rule cases

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*