### PR TITLE
Working CSV export + SVG blueprint / CAD output

### DIFF
--- a/src/main/java/org/example/flowmod/utils/CsvWriter.java
+++ b/src/main/java/org/example/flowmod/utils/CsvWriter.java
@@ -1,0 +1,27 @@
+package org.example.flowmod.utils;
+
+import org.example.flowmod.HoleLayout;
+import org.example.flowmod.HoleSpec;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.file.Path;
+
+/** Utility for exporting hole layouts to CSV. */
+public final class CsvWriter {
+    private CsvWriter() {}
+
+    /**
+     * Write the given layout to a CSV file.
+     * @param path destination file
+     * @param layout hole layout to export
+     */
+    public static void write(Path path, HoleLayout layout) throws IOException {
+        try (PrintWriter pw = new PrintWriter(path.toFile())) {
+            pw.println("Row,Pos_mm,Dia_mm");
+            for (HoleSpec h : layout.holes()) {
+                pw.printf("%d,%.1f,%.1f%n", h.index(), h.positionMm(), h.diameterMm());
+            }
+        }
+    }
+}

--- a/src/main/java/org/example/flowmod/utils/SvgWriter.java
+++ b/src/main/java/org/example/flowmod/utils/SvgWriter.java
@@ -1,0 +1,34 @@
+package org.example.flowmod.utils;
+
+import org.example.flowmod.HoleLayout;
+import org.example.flowmod.HoleSpec;
+import org.example.flowmod.engine.PipeSpecs;
+
+/** Utility for producing simple SVG blueprints. */
+public final class SvgWriter {
+    private SvgWriter() {}
+
+    /**
+     * Convert the layout to an SVG string.
+     * @param layout hole layout
+     * @param pipe associated pipe specs
+     * @return SVG markup string
+     */
+    public static String toSvg(HoleLayout layout, PipeSpecs pipe) {
+        double width = pipe.modifierLengthMm();
+        double height = Math.PI * pipe.innerDiameterMm();
+        double half = height / 2.0;
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format(
+                "<svg xmlns='http://www.w3.org/2000/svg' width='%.1fmm' height='%.1fmm' viewBox='0 0 %.1f %.1f'>",
+                width, height, width, height));
+        sb.append(String.format("<rect x='0' y='0' width='%.1f' height='%.1f' fill='none' stroke='black'/>",
+                width, height));
+        for (HoleSpec h : layout.holes()) {
+            sb.append(String.format("<circle cx='%.1f' cy='%.1f' r='%.1f'/>",
+                    h.positionMm(), half, h.diameterMm() / 2.0));
+        }
+        sb.append("</svg>");
+        return sb.toString();
+    }
+}

--- a/src/test/java/org/example/flowmod/CsvWriterTest.java
+++ b/src/test/java/org/example/flowmod/CsvWriterTest.java
@@ -1,0 +1,22 @@
+package org.example.flowmod;
+
+import org.example.flowmod.utils.CsvWriter;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CsvWriterTest {
+    @Test
+    void writesHeader() throws Exception {
+        HoleLayout layout = new HoleLayout(List.of(new HoleSpec(1, 0.0, 4.0, 0.0)), 0.0);
+        Path tmp = Files.createTempFile("layout", ".csv");
+        CsvWriter.write(tmp, layout);
+        List<String> lines = Files.readAllLines(tmp);
+        assertFalse(lines.isEmpty());
+        assertEquals("Row,Pos_mm,Dia_mm", lines.get(0));
+    }
+}

--- a/src/test/java/org/example/flowmod/SvgWriterTest.java
+++ b/src/test/java/org/example/flowmod/SvgWriterTest.java
@@ -1,0 +1,24 @@
+package org.example.flowmod;
+
+import org.example.flowmod.engine.PipeSpecs;
+import org.example.flowmod.utils.SvgWriter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+public class SvgWriterTest {
+    @Test
+    void svgContainsCircles() {
+        HoleLayout layout = new HoleLayout(List.of(
+                new HoleSpec(1, 10.0, 4.0, 0.0),
+                new HoleSpec(2, 20.0, 5.0, 0.0)
+        ), 0.0);
+        PipeSpecs pipe = new PipeSpecs(20, 10, 40);
+        String svg = SvgWriter.toSvg(layout, pipe);
+        assertTrue(svg.startsWith("<svg"));
+        int count = svg.split("<circle", -1).length - 1;
+        assertEquals(2, count);
+    }
+}


### PR DESCRIPTION
## Summary
- implement CSV export via `CsvWriter`
- generate SVG blueprint with new `SvgWriter`
- show blueprint preview and enable CSV/SVG export buttons after calculating
- add unit tests for new utilities

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*