### PR TITLE
UI no-freeze, optimiser guard, full-width table, export buttons live

### DIFF
--- a/src/main/java/org/example/flowmod/engine/DesignResult.java
+++ b/src/main/java/org/example/flowmod/engine/DesignResult.java
@@ -2,4 +2,8 @@ package org.example.flowmod.engine;
 
 import org.example.flowmod.HoleLayout;
 
-public record DesignResult(HoleLayout holeLayout, VaneLayout vaneLayout, double worstCaseErrorPct) {}
+/** Aggregates the results of a modifier design. */
+public record DesignResult(PipeSpecs pipe,
+                           HoleLayout holeLayout,
+                           VaneLayout vaneLayout,
+                           double worstCaseErrorPct) {}

--- a/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
@@ -28,6 +28,6 @@ public final class GraduatedHoleOptimizer implements ModifierDesignStrategy {
             specs.add(new HoleSpec(i + 1, position, snapped, flowPerHole));
         }
         HoleLayout layout = new HoleLayout(specs, 0.0);
-        return new DesignResult(layout, null, 0.0);
+        return new DesignResult(pipe, layout, null, 0.0);
     }
 }

--- a/src/main/java/org/example/flowmod/engine/VaneDiffuserOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/VaneDiffuserOptimizer.java
@@ -17,6 +17,6 @@ public class VaneDiffuserOptimizer implements ModifierDesignStrategy {
             vanes.add(new VaneSpec(30.0, spacing, 1.0, spacing * (i + 1)));
         }
         VaneLayout layout = new VaneLayout(vanes);
-        return new DesignResult(null, layout, 0.0);
+        return new DesignResult(pipe, null, layout, 0.0);
     }
 }

--- a/src/main/java/org/example/flowmod/model3d/ExportService.java
+++ b/src/main/java/org/example/flowmod/model3d/ExportService.java
@@ -1,10 +1,16 @@
 package org.example.flowmod.model3d;
 
+import javafx.scene.control.Alert;
 import javafx.scene.shape.TriangleMesh;
+import javafx.stage.FileChooser;
+import org.example.flowmod.engine.DesignResult;
+import org.example.flowmod.utils.CsvWriter;
+import org.example.flowmod.utils.SvgWriter;
 import java.nio.file.Path;
 import java.util.Optional;
 
 import java.io.File;
+import java.io.PrintWriter;
 
 public final class ExportService {
     private ExportService() {}
@@ -15,5 +21,41 @@ public final class ExportService {
     public static Optional<Path> saveAsStl(File file, TriangleMesh mesh) {
         // TODO implement STL export
         return Optional.empty();
+    }
+
+    /** Save the current layout to a CSV file. */
+    public static void saveCsv(DesignResult result) {
+        if (result == null || result.holeLayout() == null) return;
+        FileChooser fc = new FileChooser();
+        fc.setInitialFileName("layout.csv");
+        File file = fc.showSaveDialog(null);
+        if (file == null) return;
+        try {
+            CsvWriter.write(file.toPath(), result.holeLayout());
+            Alert a = new Alert(Alert.AlertType.INFORMATION,
+                    "CSV saved to " + file.getAbsolutePath());
+            a.setHeaderText(null);
+            a.showAndWait();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    /** Save a simple SVG blueprint of the layout. */
+    public static void saveSvg(DesignResult result) {
+        if (result == null || result.holeLayout() == null || result.pipe() == null) return;
+        FileChooser fc = new FileChooser();
+        fc.setInitialFileName("layout.svg");
+        File file = fc.showSaveDialog(null);
+        if (file == null) return;
+        try (PrintWriter pw = new PrintWriter(file)) {
+            pw.print(SvgWriter.toSvg(result.holeLayout(), result.pipe()));
+            Alert a = new Alert(Alert.AlertType.INFORMATION,
+                    "SVG saved to " + file.getAbsolutePath() + " (import into CAD or convert to DXF)");
+            a.setHeaderText(null);
+            a.showAndWait();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
     }
 }

--- a/src/test/java/org/example/flowmod/OptimiserInfiniteLoopTest.java
+++ b/src/test/java/org/example/flowmod/OptimiserInfiniteLoopTest.java
@@ -1,0 +1,16 @@
+package org.example.flowmod;
+
+import org.example.flowmod.engine.PerforatedCoreOptimizer;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import java.time.Duration;
+
+public class OptimiserInfiniteLoopTest {
+    @Test
+    void loopAbortsWithinTime() {
+        assertTimeoutPreemptively(Duration.ofSeconds(1), () ->
+                assertThrows(IllegalStateException.class, () ->
+                        PerforatedCoreOptimizer.autoDesign(0, 100, 1.0, 0.5, 1.0)
+                ));
+    }
+}


### PR DESCRIPTION
## Summary
- prevent `PerforatedCoreOptimizer` looping forever
- make optimisation run on a background `Task`
- resize results table via `BorderPane.center`
- gate export buttons on presence of a `DesignResult`
- add CSV/SVG exports to `ExportService`
- test guard triggers on impossible inputs

## Testing
- `./mvnw -q test` *(fails: Could not find or load main class org.apache.maven.wrapper.MavenWrapperMain)*