### PR TITLE
Handle one-row case in optimizer

### DIFF
--- a/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/GraduatedHoleOptimizer.java
@@ -20,12 +20,20 @@ public final class GraduatedHoleOptimizer implements ModifierDesignStrategy {
                                  int rows,
                                  double Cd) {
         List<HoleSpec> specs = new ArrayList<>();
-        double flowPerHole = pipe.flowRateLpm() / rows;
-        for (int i = 0; i < rows; i++) {
-            double position = (i + 1) * pipe.modifierLengthMm() / (rows + 1);
-            double dia = drillMinMm + (drillMaxMm - drillMinMm) * i / (rows - 1.0);
-            double snapped = Math.round(dia * 2.0) / 2.0;
-            specs.add(new HoleSpec(i + 1, position, snapped, flowPerHole));
+
+        if (rows <= 1) {
+            if (rows == 1) {
+                double position = pipe.modifierLengthMm() / 2.0;
+                specs.add(new HoleSpec(1, position, drillMinMm, pipe.flowRateLpm()));
+            }
+        } else {
+            double flowPerHole = pipe.flowRateLpm() / rows;
+            for (int i = 0; i < rows; i++) {
+                double position = (i + 1) * pipe.modifierLengthMm() / (rows + 1);
+                double dia = drillMinMm + (drillMaxMm - drillMinMm) * i / (rows - 1.0);
+                double snapped = Math.round(dia * 2.0) / 2.0;
+                specs.add(new HoleSpec(i + 1, position, snapped, flowPerHole));
+            }
         }
         HoleLayout layout = new HoleLayout(specs, 0.0);
         return new DesignResult(pipe, layout, null, 0.0);

--- a/src/test/java/org/example/flowmod/HoleOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/HoleOptimizerTest.java
@@ -16,4 +16,16 @@ public class HoleOptimizerTest {
         assertTrue(result.worstCaseErrorPct() <= 5.0);
         assertEquals(10, layout.holes().size());
     }
+
+    @Test
+    void singleRowUsesMinimumDrillSize() {
+        PipeSpecs pipe = new PipeSpecs(20, 5, 100);
+        FilterSpecs filter = new FilterSpecs(30, 1.0);
+        DesignResult result = HoleOptimizer.optimise(pipe, filter, 1.0, 5.0, 1, 0.62);
+        HoleLayout layout = result.holeLayout();
+        assertEquals(1, layout.holes().size());
+        HoleSpec hole = layout.holes().get(0);
+        assertEquals(pipe.modifierLengthMm() / 2.0, hole.positionMm(), 0.0001);
+        assertEquals(1.0, hole.diameterMm(), 0.0001);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid division by zero when optimizer receives one row
- add regression test for one-row scenario

## Testing
- `./mvnw -q test` *(fails: UnknownHostException)*