### PR TITLE
Handle NaN pressure drop

### DIFF
--- a/src/main/java/org/example/flowmod/engine/PerforatedCoreOptimizer.java
+++ b/src/main/java/org/example/flowmod/engine/PerforatedCoreOptimizer.java
@@ -197,7 +197,7 @@ public final class PerforatedCoreOptimizer {
                                              int holes,
                                              double drillStepMm) {
         double dpStart = FlowPhysics.compute(pipe).pressureDropPaPerM() * (stripLengthMm / 1000.0);
-        if (dpStart <= 0) {
+        if (Double.isNaN(dpStart) || dpStart <= 0) {
             dpStart = 1000.0;
         }
         double dpEnd = dpStart * 0.2;

--- a/src/test/java/org/example/flowmod/PerforatedCoreOptimizerTest.java
+++ b/src/test/java/org/example/flowmod/PerforatedCoreOptimizerTest.java
@@ -83,4 +83,16 @@ public class PerforatedCoreOptimizerTest {
             assertTrue(pitch >= h.diameterMm() + 0.6);
         }
     }
+
+    @Test
+    void zeroDiameterProducesFiniteLayout() {
+        PipeSpecs pipe = new PipeSpecs(0, 50, 100);
+        HoleLayout layout = PerforatedCoreOptimizer.design(pipe, 100, 50, 1.0, 5.0, 5.0);
+        assertFalse(Double.isNaN(layout.worstCaseErrorPct()));
+        for (HoleSpec h : layout.holes()) {
+            assertFalse(Double.isNaN(h.diameterMm()));
+            assertFalse(Double.isNaN(h.positionMm()));
+            assertFalse(Double.isNaN(h.predictedLpm()));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- guard against `NaN` pressure drop when designing layouts
- test zero-diameter case to ensure layout values remain finite

## Testing
- `./mvnw -q test` *(fails: UnknownHostException)*